### PR TITLE
グループ名ではなくグループIDをfrontmattersに利用するように変更

### DIFF
--- a/autoload/metarw/docbase/post.vim
+++ b/autoload/metarw/docbase/post.vim
@@ -41,7 +41,7 @@ function! metarw#docbase#post#read(urn) abort
 
   " frontmatters:
   let l:tags = map(get(l:post, 'tags', []), { _, t -> t.name })
-  let l:groups = map(get(l:post, 'groups', []), { _, g -> g.name })
+  let l:groups = map(get(l:post, 'groups', []), { _, g -> g.id })
   let l:scope = get(l:post, 'scope', v:null)
   let l:content = [
     \ '---',


### PR DESCRIPTION
POST/PUT APIがグループ名ではなくグループIDを受け付けるようで、グループが指定された既存記事を編集して保存する際にエラーが出てしまったので、グループIDを利用するよう変更しました。
参考: https://help.docbase.io/posts/92981